### PR TITLE
Added PHP-Mapscript Layer setFilter test

### DIFF
--- a/php/layerObjTest.php
+++ b/php/layerObjTest.php
@@ -3,11 +3,26 @@
 class LayerObjTest extends PHPUnit_Framework_TestCase
 {
     protected $layer;
+    protected $map;
 
     public function setUp()
     {
-        $map = new mapObj('maps/filter.map');
-        $this->layer = $map->getLayer(0);
+        $this->map = new mapObj('maps/filter.map');
+        $this->layer = $this->map->getLayer(0);
+    }
+
+    public function testSetFilter()
+    {
+        $this->assertEquals(0, $this->layer->setFilter("('[CTY_NAME]' = 'Itasca')"));
+        $this->assertEquals("('[CTY_NAME]' = 'Itasca')", $this->layer->getFilterString());
+        $this->layer->queryByRect($this->map->extent);
+        $this->assertEquals(1,$this->layer->getNumResults());
+        $this->assertEquals(0, $this->layer->setFilter("('[CTY_ABBR]' = 'BECK')"));
+        $this->layer->queryByRect($this->map->extent);
+        $this->assertEquals(1,$this->layer->getNumResults());
+        $this->assertEquals(0, $this->layer->setFilter("('[WRONG]' = 'wrong')"));
+        @$this->layer->queryByRect($this->map->extent);
+        $this->assertEquals(0,$this->layer->getNumResults());
     }
 
     public function testqueryByFilter()

--- a/php/maps/filter.map
+++ b/php/maps/filter.map
@@ -16,7 +16,8 @@
 #
 MAP
   NAME 'filters'
-  EXTENT 125000 4785000 789000 5489000
+  #EXTENT 125000 4785000 789000 5489000
+  EXTENT 189775.332039 4816305.370038 761655.073439 5472427.737000
   UNITS METERS
   SIZE 300 300
   IMAGETYPE GIF
@@ -24,8 +25,9 @@ MAP
   # Logical expression, string equality
   LAYER
     NAME 'filters_test005'
-    FILTER ('[CTY_NAME]' = 'Itasca')
+    #FILTER ('[CTY_NAME]' = 'Itasca')
     INCLUDE 'include/bdry_counpy2_shapefile.map'
+    TEMPLATE 'void'
   END
 
 END


### PR DESCRIPTION
Adds a test to the setFilter function on a Layer in PHP-Mapscript.

It sets a filter, verify it has been set with getFilterString then run a queryByRect on the map's extent and make sure there's only one result.
