### PR TITLE
WMS request now tests for ScaleDenom and return valid XML.

### DIFF
--- a/wxs/expected/ows_wms_capabilities.xml
+++ b/wxs/expected/ows_wms_capabilities.xml
@@ -16,6 +16,15 @@ Content-Type: text/xml
 
 <Capability>
   <Request>
+    <GetCapabilities>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/ows?"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/ows?"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
     <GetMap>
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
@@ -85,6 +94,7 @@ Content-Type: text/xml
              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://localhost/path/to/ows?version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=road2&amp;format=image/png&amp;STYLE=default"/>
           </LegendURL>
         </Style>
+        <MinScaleDenominator>1500</MinScaleDenominator>
       </Layer>
       <Layer queryable="1" opaque="0" cascaded="0">
         <Name>road3</Name>

--- a/wxs/expected/wms_inspire_cap.xml
+++ b/wxs/expected/wms_inspire_cap.xml
@@ -335,6 +335,7 @@
              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.geodaten-mv.de/dienste/inspirevs_test?language=ger&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=TN.CommonTransportElements.TransportLink&amp;format=image/png&amp;STYLE=TN.CommonTransportElements.TransportLink.Default"/>
           </LegendURL>
         </Style>
+        <MinScaleDenominator>5146</MinScaleDenominator>
       </Layer>
       <Layer queryable="1" opaque="0" cascaded="0">
         <Name>TN.CommonTransportElements.TransportNode</Name>

--- a/wxs/expected/wms_inspire_cap_111.xml
+++ b/wxs/expected/wms_inspire_cap_111.xml
@@ -318,6 +318,8 @@
              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.geodaten-mv.de/dienste/inspirevs_test?language=ger&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=TN.CommonTransportElements.TransportLink&amp;format=image/png&amp;STYLE=TN.CommonTransportElements.TransportLink.Default"/>
           </LegendURL>
         </Style>
+        <ScaleHint min="2.5673540580189" max="0" />
+        <!-- WARNING: Only MINSCALEDENOM and no MAXSCALEDENOM specified in the mapfile. A default value of 0 has been returned for the Max ScaleHint but this is probably not what you want. -->
       </Layer>
       <Layer queryable="1" opaque="0" cascaded="0">
         <Name>TN.CommonTransportElements.TransportNode</Name>

--- a/wxs/expected/wms_inspire_cap_111_eng.xml
+++ b/wxs/expected/wms_inspire_cap_111_eng.xml
@@ -315,6 +315,8 @@
              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.geodaten-mv.de/dienste/inspirevs_test?language=eng&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=TN.CommonTransportElements.TransportLink&amp;format=image/png&amp;STYLE=TN.CommonTransportElements.TransportLink.Default"/>
           </LegendURL>
         </Style>
+        <ScaleHint min="2.5673540580189" max="0" />
+        <!-- WARNING: Only MINSCALEDENOM and no MAXSCALEDENOM specified in the mapfile. A default value of 0 has been returned for the Max ScaleHint but this is probably not what you want. -->
       </Layer>
       <Layer queryable="1" opaque="0" cascaded="0">
         <Name>TN.CommonTransportElements.TransportNode</Name>

--- a/wxs/expected/wms_inspire_cap_111_ger.xml
+++ b/wxs/expected/wms_inspire_cap_111_ger.xml
@@ -318,6 +318,8 @@
              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.geodaten-mv.de/dienste/inspirevs_test?language=ger&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=TN.CommonTransportElements.TransportLink&amp;format=image/png&amp;STYLE=TN.CommonTransportElements.TransportLink.Default"/>
           </LegendURL>
         </Style>
+        <ScaleHint min="2.5673540580189" max="0" />
+        <!-- WARNING: Only MINSCALEDENOM and no MAXSCALEDENOM specified in the mapfile. A default value of 0 has been returned for the Max ScaleHint but this is probably not what you want. -->
       </Layer>
       <Layer queryable="1" opaque="0" cascaded="0">
         <Name>TN.CommonTransportElements.TransportNode</Name>

--- a/wxs/expected/wms_inspire_cap_eng.xml
+++ b/wxs/expected/wms_inspire_cap_eng.xml
@@ -332,6 +332,7 @@
              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.geodaten-mv.de/dienste/inspirevs_test?language=eng&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=TN.CommonTransportElements.TransportLink&amp;format=image/png&amp;STYLE=TN.CommonTransportElements.TransportLink.Default"/>
           </LegendURL>
         </Style>
+        <MinScaleDenominator>5146</MinScaleDenominator>
       </Layer>
       <Layer queryable="1" opaque="0" cascaded="0">
         <Name>TN.CommonTransportElements.TransportNode</Name>

--- a/wxs/expected/wms_inspire_cap_ger.xml
+++ b/wxs/expected/wms_inspire_cap_ger.xml
@@ -335,6 +335,7 @@
              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.geodaten-mv.de/dienste/inspirevs_test?language=ger&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=TN.CommonTransportElements.TransportLink&amp;format=image/png&amp;STYLE=TN.CommonTransportElements.TransportLink.Default"/>
           </LegendURL>
         </Style>
+        <MinScaleDenominator>5146</MinScaleDenominator>
       </Layer>
       <Layer queryable="1" opaque="0" cascaded="0">
         <Name>TN.CommonTransportElements.TransportNode</Name>

--- a/wxs/expected/wms_inspire_styles_all.xml
+++ b/wxs/expected/wms_inspire_styles_all.xml
@@ -62,6 +62,7 @@
 <se:FeatureTypeStyle>
 <se:Rule>
 <se:Name>TN.CommonTransportElements.TransportLink</se:Name>
+<se:MinScaleDenominator>5146.000000</se:MinScaleDenominator>
 <se:LineSymbolizer>
 <se:Stroke>
 <se:SvgParameter name="stroke">#000000</se:SvgParameter>
@@ -71,6 +72,7 @@
 </se:Rule>
 <se:Rule>
 <se:Name>TN.CommonTransportElements.TransportLink</se:Name>
+<se:MinScaleDenominator>5146.000000</se:MinScaleDenominator>
 <se:LineSymbolizer>
 <se:Stroke>
 <se:SvgParameter name="stroke">#000000</se:SvgParameter>

--- a/wxs/expected/wms_inspire_styles_commontransportelements.xml
+++ b/wxs/expected/wms_inspire_styles_commontransportelements.xml
@@ -62,6 +62,7 @@
 <se:FeatureTypeStyle>
 <se:Rule>
 <se:Name>TN.CommonTransportElements.TransportLink</se:Name>
+<se:MinScaleDenominator>5146.000000</se:MinScaleDenominator>
 <se:LineSymbolizer>
 <se:Stroke>
 <se:SvgParameter name="stroke">#000000</se:SvgParameter>
@@ -71,6 +72,7 @@
 </se:Rule>
 <se:Rule>
 <se:Name>TN.CommonTransportElements.TransportLink</se:Name>
+<se:MinScaleDenominator>5146.000000</se:MinScaleDenominator>
 <se:LineSymbolizer>
 <se:Stroke>
 <se:SvgParameter name="stroke">#000000</se:SvgParameter>

--- a/wxs/ows_wms.map
+++ b/wxs/ows_wms.map
@@ -81,6 +81,7 @@ LAYER
     "wms_enable_request" "GetCapabilities !GetMap"
     "wms_layer_group" "/roadgroup"
   END
+  MINSCALEDENOM 1500
   TYPE LINE
   STATUS ON
   PROJECTION

--- a/wxs/wms_inspire.map
+++ b/wxs/wms_inspire.map
@@ -338,6 +338,7 @@ MAP
 
     LAYER
         NAME TN.CommonTransportElements.TransportLink
+        MINSCALEDENOM 5146
         METADATA
             "wms_title.ger" "Generisches Verkehrssegment"
             "wms_title.eng" "Common transport link"


### PR DESCRIPTION
The test have been updated for the fix I pull requested in MapServer(4546 & 4547).

I simply added a MINSCALEDENOM in the map's layer and updated the expected files for the GetCapabilities fix.
